### PR TITLE
Create install_fix.sh

### DIFF
--- a/install_fix.sh
+++ b/install_fix.sh
@@ -1,0 +1,40 @@
+#José Antonio Méndez
+# 11-AGOSTO-2018
+#
+#
+#!/bin/sh
+#Contributed by @jivoi 
+
+apt-get update
+apt-get install -y autoconf automake autopoint libtool pkg-config freetds-dev 
+
+virtualenv -p python2 portia
+source portia/bin/activate
+pip install pysmb tabulate termcolor xmltodict pyasn1 pycrypto pyOpenSSL dnspython netaddr python-nmap 
+
+ln -sf /opt /pentest
+
+#The change of directory (cd impacket) was missing
+cd /opt
+git clone https://github.com/CoreSecurity/impacket && cd impacket
+python setup.py install
+
+cd /opt
+git clone https://github.com/libyal/libesedb.git && cd libesedb
+./synclibs.sh
+./autogen.sh
+
+cd /opt
+git clone https://github.com/csababarta/ntdsxtract && cd ntdsxtract
+python setup.py install
+
+sudo pip install git+https://github.com/pymssql/pymssql.git
+
+cd /opt
+git clone https://github.com/volatilityfoundation/volatility && cd volatility
+python setup.py install
+
+cd /opt
+git clone https://github.com/SpiderLabs/portia.git && cd portia
+./portia.py
+


### PR DESCRIPTION
#The change of directory (cd impacket) was missing, it causes an execution error.

./portia.py 
Traceback (most recent call last):
  File "./portia.py", line 6, in <module>
    from deps.psexec import *
  File "/opt/portia/deps/psexec.py", line 26, in <module>
    from impacket.examples import logger
ImportError: No module named impacket.examples